### PR TITLE
calculator: use Add button offset for scrolling

### DIFF
--- a/assets/calculator.js
+++ b/assets/calculator.js
@@ -135,9 +135,9 @@ if (!articles.length) {
 }
 
 getAddArticleButton().addEventListener('click', (e) => {
-    const oldHeight = document.body.clientHeight;
+    const oldOffset = e.target.offsetTop;
     addArticle();
-    window.scrollBy(0, document.body.clientHeight - oldHeight);
+    window.scrollBy(0, e.target.offsetTop - oldOffset);
 });
 
 document.querySelector('#calculator-form').addEventListener('input', (event) => {


### PR DESCRIPTION
Body height could be modified by other elements updates when adding an article. Instead, use the offset of the add button itself which is more stable